### PR TITLE
feat: Create service command with template path

### DIFF
--- a/lib/plugins/core/lib/Core.js
+++ b/lib/plugins/core/lib/Core.js
@@ -39,7 +39,7 @@ class Core extends Plugin {
 
   loadYargsSettings(yargs) {
     yargs.command(
-      'create <service> [--template <name|path>]',
+      'create <service> [--template <template>]',
       'Create a new service',
       {
         template: {
@@ -129,7 +129,7 @@ using template "${argv.template}"`
         if (msg.includes('Not enough non-option arguments')) {
           msg = 'Create command requires service argument';
           createError = true;
-        } else if (msg.includes('Unknown argument: templatename')) {
+        } else if (msg.includes('Unknown argument: templatetemplate')) {
           msg = 'Create command only accepts 1 argument';
           createError = true;
         } else if (msg.includes('Not enough arguments following: template')) {

--- a/spec/bin/ant.spec.js
+++ b/spec/bin/ant.spec.js
@@ -34,7 +34,7 @@ async function _expectUsageInstructions(args) {
   );
   expect(stdout).toContain(`Commands:
   ant.js create <service> [--template       Create a new service
-  <name>]`);
+  <template>]`);
   expect(stdout).toContain(
     '--help, -h     Show help                                             [boolean]'
   );
@@ -244,7 +244,7 @@ ant.js --help [command]`
         'should print command help',
         () => _expectSuccessMessage(
           '--help create',
-          `ant.js create <service> [--template <name>]
+          `ant.js create <service> [--template <template>]
 
 Create a new service
 

--- a/spec/lib/plugins/core/lib/Core.spec.js
+++ b/spec/lib/plugins/core/lib/Core.spec.js
@@ -210,7 +210,7 @@ describe('lib/plugins/core/lib/Core.js', () => {
         });
         const core = new Core(ant);
         core._yargsFailed(
-          'Unknown argument: templatename',
+          'Unknown argument: templatetemplate',
           {
             handleErrorMessage: (msg, err, command) =>
               (new AntCli())._handleErrorMessage(msg, err, command)


### PR DESCRIPTION
- Adds support to template files path on create service command: "create service <service> --template <template_name|template_files_path>"