### PR TITLE
feat: Subscribe directive

### DIFF
--- a/lib/plugins/graphQL/functions/subscribe.js
+++ b/lib/plugins/graphQL/functions/subscribe.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Defines and exports the {@link subscribe} function.
+ */
+
+const AntError = require('../../../util/AntError');
+const logger = require('../../../util/logger');
+const { Observable } = require('rxjs');
+const AsyncIterableObserver = require('../lib/util/AsyncIterableObserver');
+
+/**
+ * This function resolves a GraphQL @subscribe directive value.
+ */
+async function subscribe (ant, field, directiveArgs, fieldArgs) {
+  if (ant && field && directiveArgs && directiveArgs.to) {
+    const antFunction =  ant.functionController.getFunction(directiveArgs.to);
+    if (!antFunction) {
+      logger.error(new AntError(
+        `Could not find "${directiveArgs.to}" function`
+      ));
+      return null;
+    }
+    try {
+      const currentValue = antFunction.run(fieldArgs);
+      if (currentValue instanceof Observable) {
+        return new AsyncIterableObserver(field.fieldName, currentValue);
+      }
+      return currentValue;
+    } catch (e) {
+      logger.error(new AntError(
+        `Could not run "${directiveArgs.to}" function`,
+        e
+      ));
+    }
+  }
+  return null;
+}
+
+module.exports = subscribe;

--- a/lib/plugins/graphQL/lib/GraphQL.js
+++ b/lib/plugins/graphQL/lib/GraphQL.js
@@ -18,6 +18,7 @@ const DirectiveController = require('./directives/DirectiveController');
 const Directive = require('./directives/Directive');
 const mock = require('../functions/mock');
 const resolve = require('../functions/resolve');
+const subscribe = require('../functions/subscribe');
 
 const templates = [
   new Template(
@@ -67,6 +68,16 @@ class GraphQL extends Plugin {
           this._ant,
           'resolve',
           resolve
+        )
+      ),
+      new Directive(
+        this._ant,
+        'subscribe',
+        'directive @subscribe(to: String) on FIELD_DEFINITION',
+        new AntFunction(
+          this._ant,
+          'subscribe',
+          subscribe
         )
       )
     ];

--- a/lib/plugins/graphQL/lib/util/AsyncIterableObserver.js
+++ b/lib/plugins/graphQL/lib/util/AsyncIterableObserver.js
@@ -1,0 +1,111 @@
+const assert = require('assert');
+const { Observable } = require('rxjs');
+
+class AsyncIterableObserver {
+  constructor(field, observable) {
+    assert(typeof field === 'string' && field.length > 0, 'Param "field" \
+must be a non-empty String');
+    assert(observable && observable instanceof Observable, 'Param "observable" \
+must be an instance of Observable');
+    this._fieldName = field;
+    this._pendingResolves = [];
+    this._resolvedPromises = [];
+    this._done = false;
+
+    observable.subscribe(
+      data => {
+        this._resolvePromise(data);
+      },
+      err => {
+        this._resolvePromise(err);
+      },
+      () => {
+        this._done = true;
+        this._resolvePromise();
+      }
+    );
+  }
+
+  /**
+   * Returns a Promise which resolves into the next value published
+   * by the Observable, formatted following the Iterable pattern.
+   *
+   * @example <caption>The resolved Promise when the Observable is not yet completed</caption>
+   * {
+   *   value: {
+   *     foo: 'bar'
+   *   },
+   *   done: false
+   * }
+   *
+   * @example <caption>The resolved Promise when the Observable is completed</caption>
+   * {
+   *   value: {
+   *     foo: undefined
+   *   },
+   *   done: true
+   * }
+   *
+   * @returns {Promise<Object>} a Promise that will be resolved when
+   * any data or error from the Observable arrives; or a
+   * resolved Promise with the Observable data that was already
+   * received in a past moment and cached by the internal subscriber.
+   */
+  next () {
+    if (this._resolvedPromises.length) {
+      return this._resolvedPromises.shift();
+    }
+    return new Promise(resolve => {
+      this._pendingResolves.push(resolve);
+    });
+  }
+
+  /**
+   * Given the data provided by the Observable, it creates
+   * a response following the Iterable pattern, and resolves
+   * the least recent pending Promise (if any exists) or pushes
+   * a resolved Promise into the `resolvedPromises` array.
+   *
+   * @param {Any} data Any data provided by the observable
+   */
+  _resolvePromise(data) {
+    const value = {};
+    value[this._fieldName] = data;
+
+    /**
+     * The response must follow this pattern:
+     * {
+     *   value: {
+     *     <fieldName>: <data>
+     *   },
+     *   done: <true|false>
+     * }
+     */
+    const response = {
+      value,
+      done: this._done
+    };
+    if (this._pendingResolves.length) {
+      this._pendingResolves.shift()(response);
+    } else {
+      this._resolvedPromises.push(Promise.resolve(response));
+    }
+  }
+
+  /**
+   * Implements the AsyncIterable protocol and returns a new instance
+   * of iterator. Typically the `Symbol.asyncIterator` is used to
+   * return an iterator, but `@@asyncIterator` is used as a fallback,
+   * and it is also considered when creating iterators using `iterall` lib.
+   *
+   * @returns {Object} the subscriber values iterator
+   */
+  '@@asyncIterator' () {
+    const self = this;
+    return {
+      next: () => self.next()
+    };
+  }
+}
+
+module.exports = AsyncIterableObserver;

--- a/lib/plugins/graphQL/lib/util/schemaHelper.js
+++ b/lib/plugins/graphQL/lib/util/schemaHelper.js
@@ -66,6 +66,15 @@ function generateSchema(ant, graphQL, _model) {
                 for (const arg of directive.arguments) {
                   directiveArgs[arg.name.value] = arg.value.value;
                 }
+                if (directiveName === 'subscribe') {
+                  field.subscribe = (source, fieldArgs, context, info) => antDirective.resolver.run(
+                    ant,
+                    info,
+                    directiveArgs,
+                    fieldArgs
+                  );
+                  continue;
+                }
                 const currentResolver = field.resolve;
                 field.resolve = (_, fieldArgs) => antDirective.resolver.run(
                   ant,

--- a/lib/plugins/graphQL/templates/server/default/lib/Server.js
+++ b/lib/plugins/graphQL/templates/server/default/lib/Server.js
@@ -3,9 +3,12 @@
  */
 
 const express = require('express');
+const { execute, subscribe } = require('graphql');
 const graphqlHTTP = require('express-graphql');
 const { Ant, util } = require('@back4app/antframework');
+const { SubscriptionServer } = require('subscriptions-transport-ws');
 const { logger } = util;
+const { createServer } = require('http');
 const schemaHelper = require(
   '@back4app/antframework/lib/plugins/graphQL/lib/util/schemaHelper'
 );
@@ -55,6 +58,14 @@ class Server {
      * @private
      */
     this._httpServer = null;
+
+    /**
+     * Contains the [SubscriptionServer]{@link https://github.com/apollographql/subscriptions-transport-ws/blob/master/src/server.ts}
+     * created by the Express.js application.
+     * @type {Object}
+     * @private
+     */
+    this._subscriptionServer = null;
 
     /**
      * Contains the [Express.js]{@link https://github.com/expressjs/express/blob/master/lib/application.js}
@@ -109,10 +120,26 @@ class Server {
    */
   start() {
     const port = this._config.port || 3000;
-    this._httpServer = this._app.listen(port);
+    this._httpServer = createServer(this._app);
+    this._httpServer.listen(port, () => this._startSubscriptionServer(port));
     logger.log(
       `GraphQL API server listening for requests on http://localhost:${port}`
     );
+  }
+
+  /**
+   * Starts the SubscriptionServer.
+   */
+  _startSubscriptionServer (port) {
+    logger.log(`Websocket Server is now running on ws://localhost:${port}/subscriptions`);
+    this._subscriptionServer = new SubscriptionServer({
+      schema: this._schema,
+      execute,
+      subscribe
+    }, {
+      server: this._httpServer,
+      path: '/subscriptions',
+    });
   }
 }
 

--- a/lib/plugins/graphQL/templates/server/default/package.json
+++ b/lib/plugins/graphQL/templates/server/default/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "express": "^4.16.3",
-    "express-graphql": "^0.6.12"
+    "express-graphql": "^0.6.12",
+    "subscriptions-transport-ws": "^0.9.14"
   }
 }

--- a/lib/plugins/graphQL/templates/server/default/spec/lib/Server.spec.js
+++ b/lib/plugins/graphQL/templates/server/default/spec/lib/Server.spec.js
@@ -10,6 +10,7 @@ const { graphql } = require('graphql');
 const { Config, util } = require('@back4app/antframework');
 const { logger } = util;
 const Server = require('../../lib/Server');
+const { SubscriptionServer } = require('subscriptions-transport-ws');
 
 describe('GraphQL Server - lib/Server.js', () => {
   test('should export "Server" class', () => {
@@ -96,15 +97,41 @@ describe('GraphQL Server - lib/Server.js', () => {
   });
 
   describe('Server.start', () => {
-    test('should start the server', () => {
+    test('should start the server', done => {
+      const antConfig = (new Config({
+        basePath: path.resolve(__dirname, '../support/resolvers'),
+        plugins: ['$GLOBAL/plugins/graphQL']
+      })).config;
+      expect.hasAssertions();
+      const model = `
+        schema {
+          query: Query
+        }
+  
+        type Query {
+          foo: String @fooDirective @resolve(to: "resolveFooQuery")
+          mocked: String @mock(with: "foo mock value")
+          mocked2: String @mock
+          mocked3: String @resolve
+          mocked4: String @mock(with: "foo mock value1") @mock(with: "foo mock value2")
+        }
+      `;
       const originalLog = console.log;
-      console.log = jest.fn();
-      const server = new Server();
-      server.start();
-      expect(server._httpServer).toEqual(expect.any(http.Server));
-      expect(server._httpServer.listening).toBeTruthy();
-      server._httpServer.close();
-      console.log = originalLog;
+      const server = new Server({ antConfig, model });
+      try {
+        console.log = jest.fn();
+        server.start();
+        expect(server._httpServer).toEqual(expect.any(http.Server));
+        expect(server._httpServer.listening).toBeTruthy();
+        server._httpServer.on('listening', () => {
+          expect(server._subscriptionServer).toEqual(expect.any(SubscriptionServer));
+          server._httpServer.close(() => {
+            done();
+          });
+        });
+      } finally {
+        console.log = originalLog;
+      }
     });
   });
 });

--- a/spec/lib/plugins/graphQL/functions/subscribe.spec.js
+++ b/spec/lib/plugins/graphQL/functions/subscribe.spec.js
@@ -1,0 +1,107 @@
+/**
+ * @fileoverview Tests for lib/plugins/graphQL/functions/subscribe.js file.
+ */
+
+const subscribe = require('../../../../../lib/plugins/graphQL/functions/subscribe');
+const AsyncIterableObserver = require('../../../../../lib/plugins/graphQL/lib/util/AsyncIterableObserver');
+const AntError = require('../../../../../lib/util/AntError');
+const logger = require('../../../../../lib/util/logger');
+const rxjs = require('rxjs');
+
+describe('lib/plugins/graphQL/functions/subscribe.js', () => {
+  test('should export a function', () => {
+    expect(typeof subscribe).toEqual('function');
+  });
+
+  test('should return null if subscribe args were not passed', async () => {
+    expect(await subscribe(null, null, null)).toEqual(null);
+  });
+
+  test('should return null if resolver was not found', async () => {
+    const ant = {
+      functionController: {
+        getFunction: jest.fn()
+      }
+    };
+    const field = {
+      fieldName: 'foo'
+    };
+    const directiveArgs = {
+      to: 'fooFunc'
+    };
+    expect(await subscribe(ant, field, directiveArgs)).toEqual(null);
+    expect(ant.functionController.getFunction).toHaveBeenCalledWith(directiveArgs.to);
+  });
+
+  test('should return an AsyncIterableObserver', async () => {
+    const fieldArgs = ['foo', 'bar'];
+    const ant = {
+      functionController: {
+        getFunction: jest.fn(() => {
+          return {
+            run: jest.fn(args => {
+              expect(args).toEqual(fieldArgs);
+              return rxjs.of(1);
+            })
+          };
+        })
+      }
+    };
+    const field = {
+      fieldName: 'foo'
+    };
+    const directiveArgs = {
+      to: 'fooFunc'
+    };
+    const asyncIterableObserver = await subscribe(ant, field, directiveArgs, fieldArgs);
+    expect(asyncIterableObserver).toBeInstanceOf(AsyncIterableObserver);
+    expect(asyncIterableObserver._fieldName).toBe('foo');
+  });
+
+  test('should return the AntFunction result', async () => {
+    const mockedResult = {
+      foo: 'bar'
+    };
+    const ant = {
+      functionController: {
+        getFunction: jest.fn(() => {
+          return {
+            run: jest.fn(() => {
+              return mockedResult;
+            })
+          };
+        })
+      }
+    };
+    const field = {
+      fieldName: 'foo'
+    };
+    const directiveArgs = {
+      to: 'fooFunc'
+    };
+    expect(await subscribe(ant, field, directiveArgs)).toEqual(mockedResult);
+  });
+
+  test('should log the AntFunction execution error', async () => {
+    const loggerMock = jest.spyOn(logger, 'error');
+    const ant = {
+      functionController: {
+        getFunction: jest.fn(() => {
+          return {
+            run: jest.fn(() => {
+              throw new Error('Mocked error');
+            })
+          };
+        })
+      }
+    };
+    const field = {
+      fieldName: 'foo'
+    };
+    const directiveArgs = {
+      to: 'fooFunc'
+    };
+    await subscribe(ant, field, directiveArgs);
+    expect(loggerMock).toHaveBeenCalledWith(expect.any(AntError));
+  });
+});

--- a/spec/lib/plugins/graphQL/lib/GraphQL.spec.js
+++ b/spec/lib/plugins/graphQL/lib/GraphQL.spec.js
@@ -205,8 +205,8 @@ describe('lib/plugins/graphQL/lib/GraphQL.js', () => {
     const graphQL = new GraphQL(ant);
     console.log = jest.fn((msg) => {
       expect(msg).toEqual(
-        'Server => GraphQL API server listening for requests on \
-http://localhost:3000\n'
+        expect.stringContaining('GraphQL API server listening \
+for requests on http://localhost:3000')
       );
     });
     childProcess.exec = jest.fn((command) => {
@@ -242,8 +242,8 @@ http://localhost:3000\n'
     const graphQL = new GraphQL(ant);
     console.log = jest.fn((msg) => {
       expect(msg).toEqual(
-        'Server => GraphQL API server listening for requests on \
-http://localhost:3000\n'
+        expect.stringContaining('Server => GraphQL API server \
+listening for requests on http://localhost:3000\n')
       );
     });
     childProcess.exec = jest.fn((command) => {
@@ -280,8 +280,8 @@ http://localhost:3000\n'
     const graphQL = new GraphQL(ant);
     console.log = jest.fn((msg) => {
       expect(msg).toEqual(
-        'Server => GraphQL API server listening for requests on \
-http://localhost:3000\n'
+        expect.stringContaining('Server => GraphQL API server \
+listening for requests on http://localhost:3000\n')
       );
     });
     childProcess.exec = jest.fn((command) => {
@@ -320,11 +320,13 @@ http://localhost:3000\n'
     test('should be readonly and return the default directives', () => {
       const graphQL = new GraphQL(ant);
       expect(graphQL.directives).toEqual(expect.any(Array));
-      expect(graphQL.directives).toHaveLength(2);
+      expect(graphQL.directives).toHaveLength(3);
       expect(graphQL.directives[0]).toEqual(expect.any(Directive));
       expect(graphQL.directives[0].name).toEqual('mock');
       expect(graphQL.directives[1]).toEqual(expect.any(Directive));
       expect(graphQL.directives[1].name).toEqual('resolve');
+      expect(graphQL.directives[2]).toEqual(expect.any(Directive));
+      expect(graphQL.directives[2].name).toEqual('subscribe');
     });
   });
 

--- a/spec/lib/plugins/graphQL/lib/util/AsyncIterableObserver.spec.js
+++ b/spec/lib/plugins/graphQL/lib/util/AsyncIterableObserver.spec.js
@@ -1,0 +1,128 @@
+/* eslint-disable no-console */
+/**
+ * @fileoverview Tests for lib/plugins/graphQL/lib/util/AsyncIterableObserver.js file.
+ */
+const AsyncIterableObserver = require(
+  '../../../../../../lib/plugins/graphQL/lib/util/AsyncIterableObserver'
+);
+const rxjs = require('rxjs');
+const iterall = require('iterall');
+
+describe('lib/util/AsyncIterableObserver.js', () => {
+  test('should export AsyncIterableObserver class', () => {
+    expect(AsyncIterableObserver).toBeInstanceOf(Function);
+    expect(new AsyncIterableObserver('foo', rxjs.of('foo')).constructor.name)
+      .toBe('AsyncIterableObserver');
+  });
+
+  test('should iterate over resolved promise and finish', async () => {
+    const observer = new AsyncIterableObserver('foo', rxjs.of(1, 2, 3));
+    await iterall.forAwaitEach(observer, (data, index) => {
+      expect(data).toEqual({
+        foo: index + 1
+      });
+    });
+    expect.hasAssertions();
+  });
+
+  test('should iterate over unresolved promise and finish', async () => {
+    const observer = new AsyncIterableObserver('foo', rxjs.Observable.create(
+      subscriber => {
+        let i = 0;
+        const interval = setInterval(
+          () => {
+            subscriber.next(`foo${++i}`);
+            if (i >= 3) {
+              subscriber.complete();
+              clearInterval(interval);
+            }
+          },
+          50
+        );
+        return () => {};
+      }
+    ));
+    await iterall.forAwaitEach(observer, (data, index) => {
+      expect(data).toEqual({
+        foo: `foo${index + 1}`
+      });
+    });
+    expect.hasAssertions();
+  });
+
+  test('should iterate over error', async () => {
+    const observer = new AsyncIterableObserver('foo', rxjs.Observable.create(
+      subscriber => {
+        subscriber.error('error1');
+        return () => {};
+      }
+    ));
+    const iterator = iterall.createAsyncIterator(observer);
+    expect(iterator.next()).resolves.toEqual({
+      done: false,
+      value: {
+        foo: 'error1'
+      }
+    });
+  });
+
+  test('should iterate over unresolved error', async () => {
+    const observer = new AsyncIterableObserver('foo', rxjs.Observable.create(
+      subscriber => {
+        setTimeout(() => {
+          subscriber.error('error2');
+        }, 50);
+        return () => {};
+      }
+    ));
+    const pendingPromise = observer.next();
+    expect(observer._pendingResolves).toHaveLength(1);
+    const result = await pendingPromise;
+    expect(result).toEqual({
+      value: {
+        foo: 'error2'
+      },
+      done: false
+    });
+    expect(observer._pendingResolves).toHaveLength(0);
+  });
+
+  test('should iterate over unresolved completion', async () => {
+    const observer = new AsyncIterableObserver('foo', rxjs.Observable.create(
+      subscriber => {
+        setTimeout(() => {
+          subscriber.complete();
+        }, 50);
+        return () => {};
+      }
+    ));
+    const pendingPromise = observer.next();
+    expect(observer._pendingResolves).toHaveLength(1);
+    const result = await pendingPromise;
+    expect(result).toEqual({
+      value: {
+        foo: undefined
+      },
+      done: true
+    });
+    expect(observer._pendingResolves).toHaveLength(0);
+  });
+
+  test('should return async iterator', () => {
+    const observer = new AsyncIterableObserver('foo', rxjs.of(1));
+    expect(iterall.isAsyncIterable(observer)).toBeTruthy();
+    const iterator = iterall.createAsyncIterator(observer);
+    expect(iterator.next()).resolves.toEqual({
+      value: {
+        foo: 1
+      },
+      done: false
+    });
+    expect(iterator.next()).resolves.toEqual({
+      value: {
+        foo: undefined
+      },
+      done: true
+    });
+  });
+});

--- a/spec/lib/plugins/graphQL/lib/util/schemaHelper.spec.js
+++ b/spec/lib/plugins/graphQL/lib/util/schemaHelper.spec.js
@@ -18,7 +18,32 @@ describe('lib/util/schemaHelper.js', () => {
     );
     const ant = new Ant({ basePath });
     const graphQL = new GraphQL(ant, { basePath });
+    graphQL.directiveController.loadDirectives(graphQL.directives);
     const schema = schemaHelper.generateSchema(ant, graphQL);
     expect(schema.constructor.name).toEqual('GraphQLSchema');
+  });
+
+  test('should invoke subscribe directive resolver', () => {
+    const basePath = path.resolve(
+      __dirname,
+      '../../../../../support/services/FooService'
+    );
+    const ant = new Ant({ basePath });
+    const graphQL = new GraphQL(ant, { basePath });
+    graphQL.directiveController.loadDirectives(graphQL.directives);
+    const subscribeResolverMock = jest.fn();
+    graphQL.directiveController.getDirective('subscribe')._resolver = {
+      run: subscribeResolverMock
+    };
+    const schema = schemaHelper.generateSchema(ant, graphQL);
+    const subscriptions = schema._typeMap['Subscription'];
+    const mySubsField = subscriptions._fields['mySubs'];
+    expect(mySubsField.astNode.directives[0].name.value).toBe('subscribe');
+    expect(typeof mySubsField.subscribe).toBe('function');
+
+    const field = { fieldName: 'foo'};
+    const fieldArgs = ['foo', 'bar'];
+    mySubsField.subscribe(null, fieldArgs, null, field);
+    expect(subscribeResolverMock).toHaveBeenCalledWith(graphQL.ant, field, { to: 'mySubsResolver' }, fieldArgs);
   });
 });

--- a/spec/support/services/FooService/model.graphql
+++ b/spec/support/services/FooService/model.graphql
@@ -3,8 +3,7 @@ schema {
   query: Query
   # Uncomment the line below to start designing mutations
   # mutation: Mutation
-  # Uncomment the line below to start designing subscriptions
-  # subscription: Subscription
+  subscription: Subscription
 }
 
 # Design your queries in the Query type below
@@ -17,5 +16,6 @@ type Query {
 # }
 
 # Design your subscriptions in the Subscription type below
-# type Subscription {
-# }
+type Subscription {
+  mySubs: String @subscribe(to: "mySubsResolver")
+}


### PR DESCRIPTION
Introducing the `@subscribe(to: String)` directive. Allowing users to use GraphQL subscriptions combined with the execution of AntFunctions, where subscribers will receive data whenever available using websockets.