### PR TITLE
fix: --config being ignored when commands are ran

### DIFF
--- a/lib/cli/AntCli.js
+++ b/lib/cli/AntCli.js
@@ -27,7 +27,7 @@ class AntCli {
   constructor() {
     /**
      * Contains the Ant framework local config.
-     * @type {Object}
+     * @type {Config}
      * @private
      */
     this._config = this._getAntConfig();
@@ -37,7 +37,7 @@ class AntCli {
      * @type {Ant}
      * @private
      */
-    this._ant = new Ant(this._config);
+    this._ant = new Ant(this._config ? this._config.config : null);
 
     this._loadYargs();
   }
@@ -70,7 +70,7 @@ class AntCli {
     }
     if (configPath) {
       try {
-        config = new Config(configPath).config;
+        config = new Config(configPath);
       } catch (e) {
         yargsHelper.handleErrorMessage(
           `Could not load config file ${configPath}`,
@@ -101,11 +101,11 @@ class AntCli {
       .help().alias('help', 'h')
       .version()
       .config('config', 'Path to YAML config file', () => {
-        return { configObject: this._config };
+        return { configPath: this._config ? this._config._path : null };
       }).alias('config', 'c')
-      .options('configObject', {
+      .options('configPath', {
         describe: 'Set the CLI configuration settings',
-        default: this._config,
+        default: this._config ? this._config._path : null,
         hidden: true
       })
       .options('verbose', {

--- a/lib/plugins/core/lib/Core.js
+++ b/lib/plugins/core/lib/Core.js
@@ -122,8 +122,9 @@ using template "${argv.template}"`
             });
           },
           async (argv) => {
+            console.log(argv);
             try {
-              await this.addPlugin(argv.plugin, argv.global);
+              await this.addPlugin(argv.plugin, argv.configPath || argv.global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'plugin add');
@@ -145,7 +146,7 @@ using template "${argv.template}"`
           },
           async (argv) => {
             try {
-              await this.removePlugin(argv.plugin, argv.global);
+              await this.removePlugin(argv.plugin, argv.configPath || argv.global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'plugin remove');
@@ -178,7 +179,7 @@ using template "${argv.template}"`
           },
           async (argv) => {
             try {
-              await this.addTemplate(argv.category, argv.template, argv.path, argv.global);
+              await this.addTemplate(argv.category, argv.template, argv.path, argv.configPath || argv.global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'template add');
@@ -203,7 +204,7 @@ using template "${argv.template}"`
           },
           async (argv) => {
             try {
-              await this.removeTemplate(argv.category, argv.template, argv.global);
+              await this.removeTemplate(argv.category, argv.template, argv.configPath || argv.global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'template remove');
@@ -253,8 +254,8 @@ using template "${argv.template}"`
           },
           async argv => {
             try {
-              const { name, function: func, runtime, type, global } = argv;
-              await this.addFunction(name, func, runtime, type, global);
+              const { name, function: func, runtime, type, configPath, global } = argv;
+              await this.addFunction(name, func, runtime, type, configPath || global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'function add');
@@ -276,8 +277,8 @@ using template "${argv.template}"`
           },
           async argv => {
             try {
-              const { name, global } = argv;
-              await this.removeFunction(name, global);
+              const { name, configPath, global } = argv;
+              await this.removeFunction(name, configPath || global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'function remove');
@@ -356,8 +357,8 @@ using template "${argv.template}"`
           },
           async (argv) => {
             try {
-              const { name, bin, extensions, global } = argv;
-              await this.addRuntime(name, bin, extensions, global);
+              const { name, bin, extensions, configPath, global } = argv;
+              await this.addRuntime(name, bin, extensions, configPath || global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'runtime add');
@@ -379,8 +380,8 @@ using template "${argv.template}"`
           },
           async (argv) => {
             try {
-              const { name, global } = argv;
-              await this.removeRuntime(name, global);
+              const { name, configPath, global } = argv;
+              await this.removeRuntime(name, configPath || global);
               process.exit(0);
             } catch (e) {
               yargsHelper.handleErrorMessage(e.message, e, 'runtime remove');
@@ -632,27 +633,27 @@ Considering "${template}" as the template files path.`);
    * Adds a plugin into a configuration file
    *
    * @param {!String} plugin The path to the plugin files
-   * @param {Boolean} isGlobal Checked if the plugin should be added on
-   * the global configuration file. If not, the plugin will be added on
-   * the local configuration file.
+   * @param {String|Boolean} config The configuration file path whose plugin
+   * will be added; or a flag indicating this change should be done on the
+   * global configuration (if true), or local configuration (if false).
    * @returns {String} The path to the configuration file or null if nothing
    * was done.
    */
-  async addPlugin(plugin, isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async addPlugin(plugin, config) {
+    config = Core._getConfig(config);
     return config.addPlugin(plugin).save();
   }
 
   /**
    * @param {!String} plugin The path of the plugin to be removed
-   * @param {Boolean} isGlobal Checked if the plugin should be removed from
-   * the global configuration file. If not, the plugin will be removed from
-   * the local configuration file.
+   * @param {String|Boolean} config The configuration file path whose plugin will be removed;
+   * or a flag indicating this change should be done on the global configuration (if true),
+   * or local configuration (if false).
    * @returns {String} The path to the configuration file or null if nothing
    * was done.
    */
-  async removePlugin(plugin, isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async removePlugin(plugin, config) {
+    config = Core._getConfig(config);
     return config.removePlugin(plugin).save();
   }
 
@@ -662,12 +663,13 @@ Considering "${template}" as the template files path.`);
    * @param {!String} category The category of the template
    * @param {!String} template The name of the template to be added
    * @param {!String} templatePath The path to the template files
-   * @param {Boolean} isGlobal True if should be added into global configuration,
-   * false if it should be added into local configuration
+   * @param {String|Boolean} config The configuration file path whose template
+   * will be added; or a flag indicating this change should be done on the
+   * global configuration (if true), or local configuration (if false).
    * @returns {String} The path of the added template
    */
-  async addTemplate(category, template, templatePath, isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async addTemplate(category, template, templatePath, config) {
+    config = Core._getConfig(config);
     return config.addTemplate(category, template, templatePath).save();
   }
 
@@ -676,12 +678,13 @@ Considering "${template}" as the template files path.`);
    *
    * @param {!String} category The category of the template
    * @param {!String} template The name of the template to be removed
-   * @param {Boolean} isGlobal True if should be removed from global configuration,
-   * false if it should be removed from local configuration
+   * @param {String|Boolean} config The configuration file path whose template will be removed;
+   * or a flag indicating this change should be done on the global configuration (if true),
+   * or local configuration (if false).
    * @returns {String} The path of the removed template
    */
-  async removeTemplate(category, template, isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async removeTemplate(category, template, config) {
+    config = Core._getConfig(config);
     return config.removeTemplate(category, template).save();
   }
 
@@ -706,11 +709,12 @@ Considering "${template}" as the template files path.`);
    * @param {String} func The path of the function
    * @param {Runtime} runtime The runtime to run the function
    * @param {String} type The type of the AntFunction that will be added
-   * @param {Boolean} isGlobal True if should be added into global configuration,
-   * false if it should be added into local configuration
+   * @param {String|Boolean} config The configuration file path whose function
+   * will be added; or a flag indicating this change should be done on the
+   * global configuration (if true), or local configuration (if false).
    */
-  async addFunction(name, func, runtime, type = 'lib', isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async addFunction(name, func, runtime, type = 'lib', config) {
+    config = Core._getConfig(config);
     switch(type) {
     case 'lib':
       /* eslint-disable no-case-declarations */
@@ -743,11 +747,12 @@ Considering "${template}" as the template files path.`);
    * Removes a function from the configuration file and saves it.
    *
    * @param {!String} name The name of the function to be removed
-   * @param {Boolean} isGlobal True if should be removed from global configuration,
-   * false if it should be removed from local configuration
+   * @param {String|Boolean} config The configuration file path whose function will be removed;
+   * or a flag indicating this change should be done on the global configuration (if true),
+   * or local configuration (if false).
    */
-  async removeFunction(name, isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async removeFunction(name, config) {
+    config = Core._getConfig(config);
     return config.removeFunction(name).save();
   }
 
@@ -792,11 +797,12 @@ Considering "${template}" as the template files path.`);
    * @param {!String} name The name of the runtime to be added
    * @param {!String} bin The path to the runtime
    * @param {Array} extensions The extensions supported by the runtime
-   * @param {Boolean} isGlobal True if should be added into global configuration,
-   * false if it should be added into local configuration
+   * @param {String|Boolean} config The configuration file path whose runtime
+   * will be added; or a flag indicating this change should be done on the
+   * global configuration (if true), or local configuration (if false).
    */
-  async addRuntime(name, bin, extensions, isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async addRuntime(name, bin, extensions, config) {
+    config = Core._getConfig(config);
     return config.addRuntime(new Runtime(
       this.ant, name, bin, extensions
     )).save();
@@ -806,11 +812,12 @@ Considering "${template}" as the template files path.`);
    * Removes a runtime from the configuration file and saves it.
    *
    * @param {!String} name The name of the runtime to be removed
-   * @param {Boolean} isGlobal True if should be removed from global configuration,
-   * false if it should be removed from local configuration
+   * @param {String|Boolean} config The configuration file path whose runtime will be removed;
+   * or a flag indicating this change should be done on the global configuration (if true),
+   * or local configuration (if false).
    */
-  async removeRuntime(name, isGlobal) {
-    const config = Core._getConfig(isGlobal);
+  async removeRuntime(name, config) {
+    config = Core._getConfig(config);
     return config.removeRuntime(name).save();
   }
 
@@ -830,13 +837,17 @@ Considering "${template}" as the template files path.`);
   /**
    * Returns an instance of global or local configuration.
    *
-   * @param {Boolean} isGlobal flag indicating it should return an instance
-   * of global configuration. If false, returns an instance of local configuration.
+   * @param {String|Boolean} config The configuration file path, or a boolean
+   * indicating it should return an instance of global configuration if true,
+   * or an instance of local configuration.
    * @static
    * @private
    */
-  static _getConfig(isGlobal) {
-    return isGlobal ? Config.Global : new Config(Config.GetLocalConfigPath());
+  static _getConfig(config) {
+    if (typeof config === 'string') {
+      return new Config(config);
+    }
+    return config ? Config.Global : new Config(Config.GetLocalConfigPath());
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1720,11 +1720,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1737,15 +1739,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1848,7 +1853,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1858,6 +1864,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1870,17 +1877,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1897,6 +1907,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1969,7 +1980,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1979,6 +1991,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2084,6 +2097,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/spec/lib/plugins/core/lib/Core.spec.js
+++ b/spec/lib/plugins/core/lib/Core.spec.js
@@ -1277,4 +1277,16 @@ describe('lib/plugins/core/lib/Core.js', () => {
       });
     });
   });
+
+  describe('static methods', () => {
+    describe('_getConfig', () => {
+      test('should return an instance of Config', () => {
+        const configFilePath = path.resolve(outPath, 'ant.yml');
+        fs.ensureFileSync(configFilePath);
+        const config = Core._getConfig(configFilePath);
+        expect(config).toBeInstanceOf(Config);
+        expect(config._path).toBe(configFilePath);
+      });
+    });
+  });
 });


### PR DESCRIPTION
The `--config` option is not being considered when running commands such as `function add` or `template remove`, which modifies the configuration file directly.