### PR TITLE
fix: GraphQL API is not working for operations that return an array

### DIFF
--- a/packages/ant-util-tests/functions/barLibFunction.js
+++ b/packages/ant-util-tests/functions/barLibFunction.js
@@ -1,0 +1,7 @@
+/**
+ * @fileoverview Bar lib function for testing purposes.
+ */
+
+module.exports = count => {
+  return Array(count).fill(1);
+};

--- a/plugins/ant-graphql/functions/resolve.js
+++ b/plugins/ant-graphql/functions/resolve.js
@@ -3,7 +3,7 @@
  */
 
 const { Observable } = require('rxjs');
-const { toArray } = require('rxjs/operators');
+const { flatMap, toArray } = require('rxjs/operators');
 const { AntError, logger } = require('@back4app/ant-util');
 
 /**
@@ -33,7 +33,10 @@ async function resolve (ant, resolveArgs, fieldArgs, currentValue, model) {
           field.astNode.type &&
           field.astNode.type.kind === 'ListType'
         ) {
-          return await currentValue.pipe(toArray()).toPromise();
+          return await currentValue.pipe(
+            flatMap(data => data instanceof Array ? data : [ data ]),
+            toArray()
+          ).toPromise();
         } else {
           return await currentValue.toPromise();
         }

--- a/plugins/ant-graphql/spec/functions/resolve.spec.js
+++ b/plugins/ant-graphql/spec/functions/resolve.spec.js
@@ -78,4 +78,15 @@ describe('functions/resolve.js', () => {
     const model = { field: { astNode: { type: { kind: 'ListType' }}}};
     expect(await resolve(ant, { to: 'fooLibFunction' }, 3, 2, model)).toEqual([1, 2]);
   });
+
+  test('should resolve arrays as return value', async () => {
+    const ant = new Ant({
+      basePath: path.resolve(
+        utilPath,
+        'functions'
+      )
+    });
+    const model = { field: { astNode: { type: { kind: 'ListType' }}}};
+    expect(await resolve(ant, { to: 'barLibFunction' }, 3, undefined, model)).toEqual([1, 1, 1]);
+  });
 });


### PR DESCRIPTION
As solution, now the `resolve.js` (which represents the `@resolve` directive) flattens the `Observable` returned from the `LibFunction` invoked.
This solution fails in the case where the function returns an `Observable` that emits arrays, but in this case, the `Observable` should be handled in order to return the expected type of data.